### PR TITLE
Download: Fix valign and wrapping in download button

### DIFF
--- a/_includes/templates/download.html
+++ b/_includes/templates/download.html
@@ -12,7 +12,7 @@
 <link rel="alternate" type="application/rss+xml" href="/en/releasesrss.xml" title="Bitcoin Core releases">
 <div class="download">
   <h2>{{ page.latestversion }} {{CURRENT_RELEASE}} <a type="application/rss+xml" href="/en/releasesrss.xml"><img src="/assets/images/icons/icon_rss.svg" alt="rss" class="rssicon"></a></h2>
-  <div class="mainbutton"><a id="downloadbutton" href="{{ PATH_PREFIX }}/{{ FILE_PREFIX }}-{{ site.data.binaries.win32exe }}"><img src="/assets/images/os/but_windows.svg" alt="icon">{{ page.download }}</a></div>
+  <div class="mainbutton"><a id="downloadbutton" href="{{ PATH_PREFIX }}/{{ FILE_PREFIX }}-{{ site.data.binaries.win32exe }}"><img src="/assets/images/os/but_windows.svg" alt="icon"><span>{{ page.download }}</span></a></div>
   <div class="downloadbox">
     <p>{{ page.downloados }}</p>
     <div>

--- a/_sass/download.scss
+++ b/_sass/download.scss
@@ -24,7 +24,7 @@
         background-image:-ms-linear-gradient(bottom, #20598f 14%, #2c6fad 70%);
         background-image:linear-gradient(bottom, #20598f 14%, #2c6fad 70%);
         color:#fff;
-        padding:15px 20px 20px 68px;
+        padding:15px 20px 15px 8px;
         margin:40px 0 40px 0;
         -webkit-border-radius:12px;
         -moz-border-radius:12px;
@@ -35,11 +35,15 @@
         color:#fff;
 }
 .mainbutton img{
-        margin-right:10px;
-        margin-left:-52px;
-        margin-bottom:-12px;
         height:42px;
         width:42px;
+        margin-right: 8px;
+        display: inline-block;
+        vertical-align: middle;
+}
+.mainbutton span{
+        display: inline-block;
+        vertical-align: middle;
 }
 
 .download{


### PR DESCRIPTION
This is not previewed, only in-browser edits which I reflected in the CSS files, to make it look like this:

### After

![capture du 2017-10-11 12-29-43](https://user-images.githubusercontent.com/3578089/31453354-e072d074-ae7f-11e7-8071-284f1cce8c6c.png)

### Before

![capture du 2017-10-11 12-31-46](https://user-images.githubusercontent.com/3578089/31453442-315393de-ae80-11e7-8c16-059e822ec42c.png)
